### PR TITLE
require 'pathname' to fix githoog install

### DIFF
--- a/bin/githoog
+++ b/bin/githoog
@@ -2,6 +2,7 @@
 
 require 'thor'
 require 'colorize'
+require 'pathname'
 
 class GitHookInstall < Thor
   include Thor::Actions

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module FileWorld
   def bin_path
     File.expand_path(File.join(File.dirname(__FILE__),


### PR DESCRIPTION
this fixes

```
githoog:87 in `git_dir`: unitialized constant GitHookInstall::Pathname (NameError)
```

when trying to run `githoog install` (and cucumber)
